### PR TITLE
= 1.1.0 - 11 Jan 2015 =

### DIFF
--- a/fx-ssl.php
+++ b/fx-ssl.php
@@ -3,7 +3,7 @@
  * Plugin Name: f(x) SSL
  * Plugin URI: http://genbu.me/plugins/fx-ssl/
  * Description: Simple SSL(HTTPS) Plugin.
- * Version: 1.0.0
+ * Version: 1.1.0
  * Author: David Chandra Purnama
  * Author URI: http://shellcreeper.com/
  *
@@ -26,7 +26,7 @@ if ( ! defined( 'WPINC' ) ) { die; }
 ------------------------------------------ */
 
 /* Set the version constant. */
-define( 'FX_SSL_VERSION', '1.0.0' );
+define( 'FX_SSL_VERSION', '1.1.0' );
 
 /* Set the constant path to the plugin path. */
 define( 'FX_SSL_PATH', trailingslashit( plugin_dir_path( __FILE__ ) ) );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -12,7 +12,7 @@ if ( ! defined( 'WPINC' ) ) { die; }
  * @since 0.1.0
  */
 function fx_ssl_active(){
-	if( force_ssl_admin() && get_option( 'fx-ssl', false ) && fx_ssl_is_https( get_bloginfo( 'url' ) ) && fx_ssl_is_https( get_bloginfo( 'wpurl' ) ) ){
+	if( force_ssl_admin() && get_option( 'fx-ssl', false ) && fx_ssl_is_https( get_option( 'home' ) ) && fx_ssl_is_https( get_option( 'siteurl' ) ) ){
 		return true;
 	}
 	return false;
@@ -59,7 +59,7 @@ function fx_ssl_template_redirect(){
 
 	/* If not loaded using HTTPS, redirect to HTTPS Url */
 	if ( !is_ssl() ) {
-		wp_redirect('https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'], 301 );
+		wp_redirect('https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'], 302 );
 		exit();
 	}
 }

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -98,14 +98,14 @@ class fx_SSL_Settings{
 	public function settings_field_ssl(){
 
 		/* Check if feature is supported. */
-		if( is_ssl() && force_ssl_admin() && fx_ssl_is_https( get_bloginfo( 'url' ) ) && fx_ssl_is_https( get_bloginfo( 'wpurl' ) ) ){
+		if( is_ssl() && force_ssl_admin() && fx_ssl_is_https( get_option( 'home' ) ) && fx_ssl_is_https( get_option( 'siteurl' ) ) ){
 			$disabled = '';
 			$option = get_option( $this->option_name, false );
 		}
 		/* Feature is not supported. */
 		else{
 			$disabled = ' disabled=disabled';
-			$option = false;
+			$option = false; // always false if requirement not met.
 		}
 	?>
 		<label for="fx_ssl_enable">

--- a/readme.txt
+++ b/readme.txt
@@ -49,6 +49,12 @@ In order to enable access to HTTPS/SSL, you need to have a SSL License and insta
 
 == Changelog ==
 
+= 1.1.0 - 11 Jan 2015 =
+* Update readme.
+* Update Notice.
+* Use get_option() instead of get_bloginfo() to get site url.
+* Use temporary redirect.
+
 = 1.0.0 - 11 Jan 2015 =
 * Init
 
@@ -56,6 +62,9 @@ In order to enable access to HTTPS/SSL, you need to have a SSL License and insta
 
 = 1.0.0 =
 initial relase.
+
+= 1.0.1 =
+Bug Fix.
 
 == Other Notes ==
 


### PR DESCRIPTION
- Update readme.
- Update Notice.
- Use get_option() instead of get_bloginfo() to get site url.
- Use temporary redirect.
